### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test/
+
+.eslintrc
+.gitignore
+.npmignore
+.nvmrc
+circle.yml


### PR DESCRIPTION
In the absence of an `.npmignore` file npm will use `.gitignore` instead, so that anything excluded from git will also be excluded from the published npm package.

D'oh.