### PR TITLE
Support setting the user outisde of the cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ class someComponent extends React.Component {
 }
 ```
 
+### Set the token
+You can set the token without interacting with cookies via the following.
+```javascript
+userStore.setToken('jwt')
+```
+
 ### Override Cookie Key
 
 By default, the JWT assumes the cookie key is `XSRF-TOKEN`. This can be overridden

--- a/src/index.js
+++ b/src/index.js
@@ -9,20 +9,22 @@ const EventEmitter = events.EventEmitter
 
 const canWarn = () => console && console.warn && typeof console.warn === 'function'
 
+const decodeToken = token => {
+  if (token) {
+    try {
+      return decode(token)
+    } catch (e) {
+      canWarn() && console.warn(`Invalid JWT: ${token}`)
+      return void 0
+    }
+  }
+}
+
 module.exports = (options) => {
   options = extend({ cookie: 'XSRF-TOKEN' }, options)
 
-  let token = cookie.get(options.cookie)
-  let user
-
-  if (token) {
-    try {
-      user = decode(token)
-    } catch (e) {
-      user = void 0
-      canWarn() && console.warn(`Invalid JWT: ${token}`)
-    }
-  }
+  let token = cookie.get && cookie.get(options.cookie)
+  let user = decodeToken(token)
 
   return extend({
     getToken () {
@@ -35,6 +37,11 @@ module.exports = (options) => {
 
     getUserId () {
       return user ? user.id : void 0
+    },
+
+    setToken (newToken) {
+      token = newToken
+      user = decodeToken(token)
     }
   }, EventEmitter.prototype)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,15 @@ describe('Token Store', () => {
     delete GLOBAL.document
   })
 
+  it('should set user after no token is present', () => {
+    const tokenStore = require('../src')()
+    tokenStore.setToken(token)
+    let user = tokenStore.getUser()
+
+    assert.equal(user.first_name, 'Mike')
+    assert.equal(user.last_name, 'Atkins')
+  })
+
   describe('sad path', () => {
     it('should not blow up when cookie is not present', () => {
       let tokenStore


### PR DESCRIPTION
This is needed for universal js to work since you can't use the DOM cookie api in node :wink: 