### PR TITLE
Provide token to refresh

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ module.exports = (options) => {
 
     let expDate = user ? new Date(user.exp * 1000 - 2 * refreshInterval) : null
     if (expDate && expDate < new Date() && options.refresh) {
-      options.refresh()
+      options.refresh(token)
       .then(tokenStore.setToken.bind(tokenStore))
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,18 @@ describe('Token Store', () => {
     })
   })
 
+  it('if token is expired, call refresh with expired token', done => {
+    ls.set(localStorageKey, token)
+    require('../src')({
+      localStorageKey,
+      refresh: (t) => {
+        assert.equal(t, token)
+        done()
+        return bluebird.resolve(updatedToken)
+      }
+    })
+  })
+
   it('if token is expired, call refresh & set token', done => {
     ls.set(localStorageKey, token)
     const tokenStore = require('../src')({


### PR DESCRIPTION
This allows for the passing of the token to the `refresh` function. In this way, the refresh function can make decisions about how to refresh the token, e.g. logout if the token is expired.