### PR TITLE
Just events

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,20 @@ React JWT user store
 ## Usage
 
 ```javascript
-let React = require('react'),
-  userStore = require('react-jwt-store')();
+const userStore = require('react-jwt-store')()
 
-class someComponent extends React.Component {
-  constructor() {
-    super(props);
+userStore.on('Token received', (token, user) => {
+  console.log(token, user)
+})
 
-    this.state = {
-      user: userStore.getUser(),
-      token: userStore.getToken()
-    };
-  }
-  render() {
-    let user = this.state.user,
-      token = this.state.token;
+userStore.init()
+```
 
-    return (
-      <div>
-        <h1>{user}</h1>
-        <h2>{token}</h1>
-  }
-}
+### Initialize
+In order to trigger the store's refresh mechanism and send data to any event
+handlers, you must call the `init` method.
+```javascript
+userStore.init()
 ```
 
 ### Set the token


### PR DESCRIPTION
Remove the methods for getting stuff out of the store and make it totally event based. Additionally adds an `init` method to start the store. This will make it work better with redux stores since we can use the event to call the store's dispatch and put the user into the state as well as removing spurious http errors from tests when the refresh fails.

Obvi a breaking change