### PR TITLE
Be able to clear refresh interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ by passing `cookie` on the `options` hash:
 
 By default, the store does not log anything, but if you pass in a `console`
 compatible logger, the store will log the state of the token as it changes.
+
+### Terminate
+
+By default, if you set token to null:
+```javascript
+userStore.setToken(null)
+```
+...an interval responsible for refreshing tokens (the one set up on init) will not be cleared.
+If you want to clear it explicitly, then you can do it with:
+```javascript
+userStore.terminate()
+```

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "local-storage": "^1.4.2",
     "xtend": "^4.0.0"
   },
-  "babel": {
-    "stage": 0
-  },
   "standard": {
     "parser": "babel-eslint",
     "globals": [

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const noop = function () { }
 module.exports = (options) => {
   let user
   let token
+  let refreshTimer
 
   options = extend({ cookie: 'XSRF-TOKEN' }, options)
 
@@ -64,7 +65,7 @@ module.exports = (options) => {
       if (token) { this.setToken(token) }
       refreshToken()
 
-      setInterval(refreshToken, refreshInterval)
+      refreshTimer = setInterval(refreshToken, refreshInterval)
     },
 
     setToken (newToken) {
@@ -78,6 +79,12 @@ module.exports = (options) => {
       logger.info('[JWT store] refreshing token', token)
       options.refresh(token)
       .then(tokenStore.setToken.bind(tokenStore))
+    },
+
+    terminate () {
+      user = undefined
+      token = undefined
+      clearInterval(refreshTimer)
     }
   }, EventEmitter.prototype)
 


### PR DESCRIPTION
The problem I am trying to solve can be explained with the example:

I wanted to log user out from react web app, so initially I just set token to null via setToken(null). But then I noticed that the interval responsible for refreshing tokens (the one set up on init) was still running and it was using token from outside which was not actually reset to null for refresh-interval after setToken(null). 

So in result I ended up being logged out, with token cookie removed, but then after next refresh-interval, new token cookie was created (token used by interval was not null after setToken(null), so I was able to use that token to get refreshed token from my api, and then set new token cookie based on that refreshed token) - so user was automatically logged in behind the scenes.